### PR TITLE
Openresty update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.15.8.3-0-alpine-fat
+FROM openresty/openresty:1.19.3.1-0-alpine-fat
 
 RUN ln -s /usr/local/openresty/bin/openresty /usr/local/bin/
 

--- a/templates/prometheus_metrics.conf
+++ b/templates/prometheus_metrics.conf
@@ -1,7 +1,7 @@
 # Prometheus metrics config
 lua_shared_dict prometheus_metrics 50M;
 
-init_by_lua_block {
+init_worker_by_lua_block {
   prometheus = require('prometheus').init('prometheus_metrics')
   metric_requests = prometheus:counter('http_requests_total', 'Number of HTTP requests', {'host', 'status', 'method'})
   metric_latency = prometheus:histogram('http_request_duration_seconds', 'HTTP request latency', {'host'})


### PR DESCRIPTION
as the version 1.15.8.3 of Openresty has a known bug it's necessary to update it to the last stable version